### PR TITLE
 implement backend-validated authentication and global 401 handling

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,6 @@
-import {type LoginForm, loginSchema} from "@/schemas/auth/login-schema.ts";
-import type {ApiResponse} from "@/types/api.ts";
-import type {LoginResponse} from "@/types/auth.ts";
+import { type LoginForm, loginSchema } from "@/schemas/auth/login-schema.ts";
+import type { ApiResponse } from "@/types/api.ts";
+import type { LoginResponse, User } from "@/types/auth.ts";
 import axiosInstance from "@/utils/axios-instance.ts";
 import {
     type LoginWithEmployeeCodeForm,
@@ -33,5 +33,10 @@ export const loginWithEmployeeCodeApi = async (
 
 export const logoutApi = async (): Promise<ApiResponse<void>> => {
     const res = await axiosInstance.post<ApiResponse<void>>("/auth/logout");
+    return res.data;
+};
+
+export const getMe = async (): Promise<ApiResponse<User>> => {
+    const res = await axiosInstance.get<ApiResponse<User>>("/auth/me");
     return res.data;
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,9 +1,11 @@
+export interface User {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+}
+
 export interface LoginResponse {
-    user: {
-        id: string;
-        name: string;
-        email: string;
-        role: string;
-    };
+    user: User;
     token: string;
 }


### PR DESCRIPTION

Description
This PR refactors the authentication system to remove reliance on client-side cookies for user details. authentication state is now strictly validated against the backend upon application startup and maintained via a global interceptor.

Key Changes
Core Architecture:

The 
AuthProvider
 now hydrates state by calling GET /auth/me instead of reading a user cookie.
Implemented a global Axios Response Interceptor that catches 401 Unauthorized responses from any endpoint and immediately triggers a logout.
Login: No longer sets a user cookie; only the token is stored.
Logout: Refactored to be non-blocking. Frontend state is cleared instantly, while the backend logout handling happens asynchronously.
API Layer:

Added 
getMe()
 function in 
src/api/auth.ts
 to support session validation.
Standardized the 
User
 interface in 
src/types/auth.ts
.
Type Safety:

Extracted and exported the 
User
 type for consistent usage across the application.
Motivation
Previously, the application derived authentication state from cookies, which could lead to "ghost sessions" where a user appeared logged in on the frontend despite having an expired or revoked token on the backend. This change ensures the frontend is always in sync with the backend's source of truth.

Testing Strategy
 Startup: Verified app calls /auth/me on reload.
 Login: Verified correct state hydration and strictly token cookie storage.
 Logout: Verified immediate UI update and network request dispatch.
 Token Expiry: Verified that manually invalidating the token triggers a redirect to login on the next API call.
Related Issues
Closes #8 